### PR TITLE
Update compressible to 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/koajs/compress/issues"
   },
   "dependencies": {
-    "compressible": "~0.1.1",
+    "compressible": "~0.2.0",
     "bytes": "~0.2.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
`0.2.x` will not include API changes, but speed will increase slightly as common `Content-Types` are added to the lookup.
