### PR TITLE
Updated filter option example in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ var koa = require('koa')
 
 var app = koa()
 app.use(compress({
-  filter: /text/i,
+  filter: function (content_type) {
+  	return /text/i.test(content_type)
+  },
   threshold: 2048,
   flush: require('zlib').Z_SYNC_FLUSH
 }))


### PR DESCRIPTION
The previous example would have caused errors since 24a9577.
Now it must be a function.
