### PR TITLE
Fix tests http methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,9 @@
     "istanbul": "^0.4.2",
     "koa": "^1.0.0",
     "mocha": "^2.4.1",
-    "should": "^3.0.0",
-    "supertest": "^1.0.0"
+    "should": "^9.0.2",
+    "should-http": "0.0.4",
+    "supertest": "^1.2.0"
   },
   "scripts": {
     "test": "NODE_ENV=test mocha --require should --reporter spec",

--- a/test/index.js
+++ b/test/index.js
@@ -8,6 +8,8 @@ var fs = require('fs')
 var path = require('path')
 var compress = require('..')
 
+require("should-http")
+
 describe('Compress', function () {
   var buffer = crypto.randomBytes(1024)
   var string = buffer.toString('hex')


### PR DESCRIPTION
Without should-http the tests will throw errors as `res.should.have.header` doesn't exist in main `should`package
Also updated dependencies for `should` and `supertest`