### PR TITLE
Remove context null test of HEAD request

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -225,7 +225,7 @@ describe('Compress', function () {
     request(app.listen())
     .head('/')
     .expect(200)
-    .expect('', function (err, res) {
+    .end(function (err, res) {
       if (err)
         return done(err)
 


### PR DESCRIPTION
For further explanation.

The `HEAD` should return null context.
Ref: https://github.com/visionmedia/superagent/blob/master/test/json.js#L142
In this project's text, `supertest` use `expect` to check `context` content.
Another reason, this project aims at compression.




 