### PR TITLE
Add brotli support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,18 @@ app.use(compress({
 
 ## Options
 
-The options are passed to `zlib`: http://nodejs.org/api/zlib.html#zlib_options
+### encoding
+
+`options[encoding]` values are passed to the respective library for the encoding.  If unspecified, will fallback to passing the full `options` object maintaining backwards compatability.
+
+- `options.gzip` - passed to `zlib`: http://nodejs.org/api/zlib.html#zlib_options
+- `options.deflate` - passed to `zlib`: http://nodejs.org/api/zlib.html#zlib_options
+
+#### brotli support
+
+Brotli support requires you add the optional dependency of `iltorb` as well as a `br` object under options.  It is recommended to only enable `brotli` support when using an output cache as the time may be significantly slower than `gzip`.
+
+- `options.br` - passed to `iltorb`: https://www.npmjs.com/package/iltorb#brotliencodeparams
 
 ### filter
 

--- a/index.js
+++ b/index.js
@@ -1,24 +1,24 @@
-"use strict";
+'use strict'
 
 /**
  * Module dependencies.
  */
 
-const compressible = require("compressible");
-const isJSON = require("koa-is-json");
-const status = require("statuses");
-const Stream = require("stream");
-const bytes = require("bytes");
-const zlib = require("zlib");
+const compressible = require('compressible')
+const isJSON = require('koa-is-json')
+const status = require('statuses')
+const Stream = require('stream')
+const bytes = require('bytes')
+const zlib = require('zlib')
 
 // optional dependency
-const brotli = (function() {
+const brotli = (function () {
   try {
-    return require("iltorb");
+    return require('iltorb')
   } catch (error) {
-    return null;
+    return null
   }
-})();
+})()
 
 /**
  * Encoding methods supported.
@@ -28,7 +28,7 @@ const encodingMethods = {
   gzip: zlib.createGzip,
   deflate: zlib.createDeflate,
   br: brotli.compressStream
-};
+}
 
 /**
  * Compress middleware.
@@ -39,57 +39,56 @@ const encodingMethods = {
  */
 
 module.exports = (options = {}) => {
-  let { filter = compressible, threshold = 1024 } = options;
-  if (typeof threshold === "string") threshold = bytes(threshold);
+  let { filter = compressible, threshold = 1024 } = options
+  if (typeof threshold === 'string') threshold = bytes(threshold)
 
   return async (ctx, next) => {
-    ctx.vary("Accept-Encoding");
+    ctx.vary('Accept-Encoding')
 
-    await next();
+    await next()
 
-    let { body } = ctx;
-    if (!body) return;
-    if (ctx.res.headersSent || !ctx.writable) return;
-    if (ctx.compress === false) return;
-    if (ctx.request.method === "HEAD") return;
-    if (status.empty[ctx.response.status]) return;
-    if (ctx.response.get("Content-Encoding")) return;
+    let { body } = ctx
+    if (!body) return
+    if (ctx.res.headersSent || !ctx.writable) return
+    if (ctx.compress === false) return
+    if (ctx.request.method === 'HEAD') return
+    if (status.empty[ctx.response.status]) return
+    if (ctx.response.get('Content-Encoding')) return
 
     // forced compression or implied
-    if (!(ctx.compress === true || filter(ctx.response.type))) return;
+    if (!(ctx.compress === true || filter(ctx.response.type))) return
 
     // identity
-    let encoding = null;
+    let encoding = null
 
     // if brotli is specified, prefer brotli
     if (brotli && options.br) {
-      encoding = ctx.acceptsEncodings("br", "identity");
+      encoding = ctx.acceptsEncodings('br', 'identity')
     }
-    if (!encoding || encoding === "identity") {
-      encoding = ctx.acceptsEncodings("gzip", "deflate", "identity");
+    if (!encoding || encoding === 'identity') {
+      encoding = ctx.acceptsEncodings('gzip', 'deflate', 'identity')
     }
 
-    if (!encoding)
-      ctx.throw(406, "supported encodings: br, gzip, deflate, identity");
-    if (encoding === "identity") return;
+    if (!encoding) { ctx.throw(406, 'supported encodings: br, gzip, deflate, identity') }
+    if (encoding === 'identity') return
 
     // json
-    if (isJSON(body)) body = ctx.body = JSON.stringify(body);
+    if (isJSON(body)) body = ctx.body = JSON.stringify(body)
 
     // threshold
-    if (threshold && ctx.response.length < threshold) return;
+    if (threshold && ctx.response.length < threshold) return
 
-    ctx.set("Content-Encoding", encoding);
-    ctx.res.removeHeader("Content-Length");
+    ctx.set('Content-Encoding', encoding)
+    ctx.res.removeHeader('Content-Length')
 
     const stream = (ctx.body = encodingMethods[encoding](
       options[encoding] || options
-    ));
+    ))
 
     if (body instanceof Stream) {
-      body.pipe(stream);
+      body.pipe(stream)
     } else {
-      stream.end(body);
+      stream.end(body)
     }
-  };
-};
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koa-compress",
   "description": "Compress middleware for koa",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "author": {
     "name": "Jonathan Ong",
     "email": "me@jongleberry.com",
@@ -26,6 +26,9 @@
     "jest": "^22.4.3",
     "koa": "^2.0.1",
     "supertest": "^3.0.0"
+  },
+  "optionalDependencies": {
+    "iltorb": "^2.4.0"
   },
   "scripts": {
     "eslint": "eslint --ignore-path .gitignore .",


### PR DESCRIPTION
Closes #21, full version bump because of behavioral change, still backwards compatible though.

Only enabled brotli if the optional dependency of `iltorb` is available and `br` option is specified.  Added notes in the readme, as well as a suggestion to only use in conjunction with an output cache.

In my own tests:

```
encoding  level/quality  time   size
gzip      9              36ms   129kb
br        11             441ms  127kb
br        8              43ms   128kb
br        6              38ms   128kb
br        5              36ms   128kb
```