### PR TITLE
Added native Brotli support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 node_js:
 - stable
 - 8
+- 10
+- 12
 language: node_js
 script:
   - npm run eslint

--- a/README.md
+++ b/README.md
@@ -36,6 +36,17 @@ By default, it uses [compressible](https://github.com/expressjs/compressible).
 Minimum response size in bytes to compress.
 Default `1024` bytes or `1kb`.
 
+### brotliOptions
+
+Koa Compress can use [Brotli compression](https://en.wikipedia.org/wiki/Brotli) on modern versions of Node
+(at least from since v11.7.0), which includes it natively. By default it is a preferred compression method
+if it is available and a user agent indicates its support by including `br` in `Accept-Encoding`
+(subject to `filter` and `threshold` described above).
+
+`brotliOptions` is the options object, which is passed to `zlib`: https://nodejs.org/api/zlib.html#zlib_class_brotlioptions
+
+If it is set to `null` Brotli compression will be skipped falling back to `gzip` and `deflate` as usual.
+
 ## Manually turning compression on and off
 
 You can always enable compression by setting `this.compress = true`.

--- a/README.md
+++ b/README.md
@@ -36,14 +36,14 @@ By default, it uses [compressible](https://github.com/expressjs/compressible).
 Minimum response size in bytes to compress.
 Default `1024` bytes or `1kb`.
 
-### brotliOptions
+### br
 
 Koa Compress can use [Brotli compression](https://en.wikipedia.org/wiki/Brotli) on modern versions of Node
 (at least from since v11.7.0), which includes it natively. By default it is a preferred compression method
 if it is available and a user agent indicates its support by including `br` in `Accept-Encoding`
 (subject to `filter` and `threshold` described above).
 
-`brotliOptions` is the options object, which is passed to `zlib`: https://nodejs.org/api/zlib.html#zlib_class_brotlioptions
+`br` is the options object, which is passed to `zlib`: https://nodejs.org/api/zlib.html#zlib_class_brotlioptions
 
 If it is set to `null` Brotli compression will be skipped falling back to `gzip` and `deflate` as usual.
 

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -297,4 +297,86 @@ describe('Compress', () => {
         done()
       })
   })
+
+  it('accept-encoding: deflate', (done) => {
+    const app = new Koa()
+
+    app.use(compress())
+    app.use(sendBuffer)
+
+    request(app.listen())
+      .get('/')
+      .set('Accept-Encoding', 'deflate')
+      .expect(200)
+      .end((err, res) => {
+        if (err) { return done(err) }
+
+        assert.equal(res.headers.vary, 'Accept-Encoding')
+        assert.equal(res.headers['content-encoding'], 'deflate')
+
+        done()
+      })
+  })
+
+  it('accept-encoding: gzip', (done) => {
+    const app = new Koa()
+
+    app.use(compress())
+    app.use(sendBuffer)
+
+    request(app.listen())
+      .get('/')
+      .set('Accept-Encoding', 'gzip, deflate')
+      .expect(200)
+      .end((err, res) => {
+        if (err) { return done(err) }
+
+        assert.equal(res.headers.vary, 'Accept-Encoding')
+        assert.equal(res.headers['content-encoding'], 'gzip')
+
+        done()
+      })
+  })
+
+  it('accept-encoding: br', (done) => {
+    if (!process.versions.brotli) return done()
+
+    const app = new Koa()
+
+    app.use(compress())
+    app.use(sendBuffer)
+
+    request(app.listen())
+      .get('/')
+      .set('Accept-Encoding', 'gzip, deflate, br')
+      .expect(200)
+      .end((err, res) => {
+        if (err) { return done(err) }
+
+        assert.equal(res.headers.vary, 'Accept-Encoding')
+        assert.equal(res.headers['content-encoding'], 'br')
+
+        done()
+      })
+  })
+
+  it('accept-encoding: br (banned, should be gzip)', (done) => {
+    const app = new Koa()
+
+    app.use(compress({brotliOptions: null}))
+    app.use(sendBuffer)
+
+    request(app.listen())
+      .get('/')
+      .set('Accept-Encoding', 'gzip, deflate, br')
+      .expect(200)
+      .end((err, res) => {
+        if (err) { return done(err) }
+
+        assert.equal(res.headers.vary, 'Accept-Encoding')
+        assert.equal(res.headers['content-encoding'], 'gzip')
+
+        done()
+      })
+  })
 })

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -363,7 +363,7 @@ describe('Compress', () => {
   it('accept-encoding: br (banned, should be gzip)', (done) => {
     const app = new Koa()
 
-    app.use(compress({brotliOptions: null}))
+    app.use(compress({ brotliOptions: null }))
     app.use(sendBuffer)
 
     request(app.listen())

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -363,7 +363,7 @@ describe('Compress', () => {
   it('accept-encoding: br (banned, should be gzip)', (done) => {
     const app = new Koa()
 
-    app.use(compress({ brotliOptions: null }))
+    app.use(compress({ br: null }))
     app.use(sendBuffer)
 
     request(app.listen())

--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ module.exports = (options = {}) => {
     // identity
     const acceptedEncodings = ['gzip', 'deflate', 'identity']
     if (brotliSupport && br !== null) acceptedEncodings.unshift('br')
-    const encoding = ctx.acceptsEncodings(...acceptedEncodings)
+    const encoding = ctx.acceptsEncodings(acceptedEncodings)
     if (!encoding) ctx.throw(406, 'supported encodings: ' + acceptedEncodings.join(', '))
     if (encoding === 'identity') return
 


### PR DESCRIPTION
* Native support if Brotli is available in Node.
* Separate options via `brotliOptions`.
* `brotliOptions` is `null` => skip Brotli.
* New CI targets to test more platforms.
* README is amended with the Brotli-specific docs.
* New comprehensive tests for all new functionality.