### PR TITLE
Use identity as default value for Accept-Encoding if it is blank or not provided

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -61,7 +61,7 @@ module.exports = (options = {}) => {
     const encodings = new Encodings({
       preferredEncodings
     })
-    encodings.parseAcceptEncoding(ctx.request.headers['accept-encoding'] || undefined)
+    encodings.parseAcceptEncoding(ctx.request.headers['accept-encoding'] || 'identity')
     const encoding = encodings.getPreferredContentEncoding()
 
     // identity === no compression


### PR DESCRIPTION
I noticed that the existing test for "no Accept-Encoding" header was not valid because the library used to test was adding a default value for it.  The test in this PR fails because of that.

I have a PR on `superagent` to allow unsetting the `Accept-Encoding` header, I suppose once that is fixed this PR could be updated.

Or there might be another hack to make the test work properly.

