### PR TITLE
docs(readme): zlib deprecation prevention

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ app.use(compress({
   },
   threshold: 2048,
   gzip: {
-    flush: require('zlib').Z_SYNC_FLUSH
+    flush: require('zlib').constants.Z_SYNC_FLUSH
   },
   deflate: {
-    flush: require('zlib').Z_SYNC_FLUSH,
+    flush: require('zlib').constants.Z_SYNC_FLUSH,
   },
   br: false // disable brotli
 }))


### PR DESCRIPTION
Access Z_SYNC_FLUSH is still possible but deprecated as you can see on [Zlib documentation](https://nodejs.org/api/zlib.html#zlib_zlib_constants).

> Previously, the constants were available directly from require('zlib'), for instance zlib.Z_NO_FLUSH. Accessing the constants directly from the module is currently still possible but is deprecated.

Prevented this deprecation by accessing Z_SYNC_FLUSH from constants namespace.