### PR TITLE
PR 110: new default

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,19 @@ The current encodings are, in order of preference: `br`, `gzip`, `deflate`.
 Setting `options[encoding] = {}` will pass those options to the encoding function.
 Setting `options[encoding] = false` will disable that encoding.
 
-### options.br
+#### options<span></span>.br
 
-[Brotli compression](https://en.wikipedia.org/wiki/Brotli) is supported in node v11.7.0+, which includes it natively. 
+[Brotli compression](https://en.wikipedia.org/wiki/Brotli) is supported in node v11.7.0+, which includes it natively.
+
+### options.defaultEncoding\<String\>
+
+An optional string, which specifies what encoders to use for requests without
+[Accept-Encoding](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Encoding).
+Default `idenity`.
+
+The standard dictates to treat such requests as `*` meaning that all compressions are permissible,
+yet it causes very practical problems when debugging servers with manual tools like `curl`, `wget`, and so on.
+If you want to enable the standard behavior, just set `defaultEncoding` to `*`.
 
 ## Manually turning compression on and off
 

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -257,7 +257,7 @@ describe('Compress', () => {
     server = app.listen()
 
     request(server)
-    .get('/')
+      .get('/')
       .set('Accept-Encoding', '')
       .end((err, res) => {
         if (err) { return done(err) }

--- a/lib/index.js
+++ b/lib/index.js
@@ -61,7 +61,7 @@ module.exports = (options = {}) => {
     const encodings = new Encodings({
       preferredEncodings
     })
-    encodings.parseAcceptEncoding(ctx.request.headers['accept-encoding'] || undefined)
+    encodings.parseAcceptEncoding(ctx.request.headers['accept-encoding'] || 'identity')
     const encoding = encodings.getPreferredContentEncoding()
 
     // identity === no compression

--- a/lib/index.js
+++ b/lib/index.js
@@ -26,7 +26,7 @@ const NO_TRANSFORM_REGEX = /(?:^|,)\s*?no-transform\s*?(?:,|$)/
  */
 
 module.exports = (options = {}) => {
-  let { filter = compressible, threshold = 1024 } = options
+  let { filter = compressible, threshold = 1024, defaultEncoding = 'identity' } = options
   if (typeof threshold === 'string') threshold = bytes(threshold)
 
   // `options.br = false` would remove it as a preferred encoding
@@ -61,7 +61,7 @@ module.exports = (options = {}) => {
     const encodings = new Encodings({
       preferredEncodings
     })
-    encodings.parseAcceptEncoding(ctx.request.headers['accept-encoding'] || 'identity')
+    encodings.parseAcceptEncoding(ctx.request.headers['accept-encoding'] || defaultEncoding)
     const encoding = encodings.getPreferredContentEncoding()
 
     // identity === no compression

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "koa-compress",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
This PR includes the code, the tests, and the docs. Incidentally, the lock file was out of sync with the package file, so it is trivially updated too.

It is built on PR #110 according to the comment https://github.com/koajs/compress/pull/110#issuecomment-645489580 as mentioned in #112

