### PR TITLE
update request tests to async/await

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -24,29 +24,26 @@ describe('Compress', () => {
   let server
   afterEach(() => { if (server) server.close() })
 
-  it('should compress strings', (done) => {
+  test('should compress strings', async (done) => {
     const app = new Koa()
 
     app.use(compress())
     app.use(sendString)
     server = app.listen()
 
-    request(server)
+    const res = await request(server)
       .get('/')
       .expect(200)
-      .end((err, res) => {
-        if (err) { return done(err) }
 
-        assert.equal(res.headers['transfer-encoding'], 'chunked')
-        assert.equal(res.headers.vary, 'Accept-Encoding')
-        assert(!res.headers['content-length'])
-        assert.equal(res.text, string)
+    assert.equal(res.headers['transfer-encoding'], 'chunked')
+    assert.equal(res.headers.vary, 'Accept-Encoding')
+    assert(!res.headers['content-length'])
+    assert.equal(res.text, string)
 
-        done()
-      })
+    done()
   })
 
-  it('should not compress strings below threshold', (done) => {
+  it('should not compress strings below threshold', async (done) => {
     const app = new Koa()
 
     app.use(compress({
@@ -55,23 +52,20 @@ describe('Compress', () => {
     app.use(sendString)
     server = app.listen()
 
-    request(server)
+    const res = await request(server)
       .get('/')
       .expect(200)
-      .end((err, res) => {
-        if (err) { return done(err) }
 
-        assert.equal(res.headers['content-length'], '2048')
-        assert.equal(res.headers.vary, 'Accept-Encoding')
-        assert(!res.headers['content-encoding'])
-        assert(!res.headers['transfer-encoding'])
-        assert.equal(res.text, string)
+    assert.equal(res.headers['content-length'], '2048')
+    assert.equal(res.headers.vary, 'Accept-Encoding')
+    assert(!res.headers['content-encoding'])
+    assert(!res.headers['transfer-encoding'])
+    assert.equal(res.text, string)
 
-        done()
-      })
+    done()
   })
 
-  it('should compress JSON body', (done) => {
+  it('should compress JSON body', async (done) => {
     const app = new Koa()
     const jsonBody = { status: 200, message: 'ok', data: string }
 
@@ -81,22 +75,19 @@ describe('Compress', () => {
     })
     server = app.listen()
 
-    request(server)
+    const res = await request(server)
       .get('/')
       .expect(200)
-      .end((err, res) => {
-        if (err) { return done(err) }
 
-        assert.equal(res.headers['transfer-encoding'], 'chunked')
-        assert.equal(res.headers.vary, 'Accept-Encoding')
-        assert(!res.headers['content-length'])
-        assert.equal(res.text, JSON.stringify(jsonBody))
+    assert.equal(res.headers['transfer-encoding'], 'chunked')
+    assert.equal(res.headers.vary, 'Accept-Encoding')
+    assert(!res.headers['content-length'])
+    assert.equal(res.text, JSON.stringify(jsonBody))
 
-        done()
-      })
+    done()
   })
 
-  it('should not compress JSON body below threshold', (done) => {
+  it('should not compress JSON body below threshold', async (done) => {
     const app = new Koa()
     const jsonBody = { status: 200, message: 'ok' }
 
@@ -106,43 +97,37 @@ describe('Compress', () => {
     })
     server = app.listen()
 
-    request(server)
+    const res = await request(server)
       .get('/')
       .expect(200)
-      .end((err, res) => {
-        if (err) { return done(err) }
 
-        assert.equal(res.headers.vary, 'Accept-Encoding')
-        assert(!res.headers['content-encoding'])
-        assert(!res.headers['transfer-encoding'])
-        assert.equal(res.text, JSON.stringify(jsonBody))
+    assert.equal(res.headers.vary, 'Accept-Encoding')
+    assert(!res.headers['content-encoding'])
+    assert(!res.headers['transfer-encoding'])
+    assert.equal(res.text, JSON.stringify(jsonBody))
 
-        done()
-      })
+    done()
   })
 
-  it('should compress buffers', (done) => {
+  it('should compress buffers', async (done) => {
     const app = new Koa()
 
     app.use(compress())
     app.use(sendBuffer)
     server = app.listen()
 
-    request(server)
+    const res = await request(server)
       .get('/')
       .expect(200)
-      .end((err, res) => {
-        if (err) { return done(err) }
 
-        assert.equal(res.headers['transfer-encoding'], 'chunked')
-        assert.equal(res.headers.vary, 'Accept-Encoding')
-        assert(!res.headers['content-length'])
+    assert.equal(res.headers['transfer-encoding'], 'chunked')
+    assert.equal(res.headers.vary, 'Accept-Encoding')
+    assert(!res.headers['content-length'])
 
-        done()
-      })
+    done()
   })
 
-  it('should compress streams', (done) => {
+  it('should compress streams', async (done) => {
     const app = new Koa()
 
     app.use(compress())
@@ -153,43 +138,37 @@ describe('Compress', () => {
     })
     server = app.listen()
 
-    request(server)
+    const res = await request(server)
       .get('/')
       .expect(200)
-      .end((err, res) => {
-        if (err) { return done(err) }
 
-        // res.should.have.header('Content-Encoding', 'gzip')
-        assert.equal(res.headers['transfer-encoding'], 'chunked')
-        assert.equal(res.headers.vary, 'Accept-Encoding')
-        assert(!res.headers['content-length'])
+    // res.should.have.header('Content-Encoding', 'gzip')
+    assert.equal(res.headers['transfer-encoding'], 'chunked')
+    assert.equal(res.headers.vary, 'Accept-Encoding')
+    assert(!res.headers['content-length'])
 
-        done()
-      })
+    done()
   })
 
-  it('should compress when ctx.compress === true', (done) => {
+  it('should compress when ctx.compress === true', async (done) => {
     const app = new Koa()
 
     app.use(compress())
     app.use(sendBuffer)
     server = app.listen()
 
-    request(server)
+    const res = await request(server)
       .get('/')
       .expect(200)
-      .end((err, res) => {
-        if (err) { return done(err) }
 
-        assert.equal(res.headers['transfer-encoding'], 'chunked')
-        assert.equal(res.headers.vary, 'Accept-Encoding')
-        assert(!res.headers['content-length'])
+    assert.equal(res.headers['transfer-encoding'], 'chunked')
+    assert.equal(res.headers.vary, 'Accept-Encoding')
+    assert(!res.headers['content-length'])
 
-        done()
-      })
+    done()
   })
 
-  it('should not compress when ctx.compress === false', (done) => {
+  it('should not compress when ctx.compress === false', async (done) => {
     const app = new Koa()
 
     app.use(compress())
@@ -199,37 +178,31 @@ describe('Compress', () => {
     })
     server = app.listen()
 
-    request(server)
+    const res = await request(server)
       .get('/')
       .expect(200)
-      .end((err, res) => {
-        if (err) { return done(err) }
 
-        assert.equal(res.headers['content-length'], '1024')
-        assert.equal(res.headers.vary, 'Accept-Encoding')
-        assert(!res.headers['content-encoding'])
-        assert(!res.headers['transfer-encoding'])
+    assert.equal(res.headers['content-length'], '1024')
+    assert.equal(res.headers.vary, 'Accept-Encoding')
+    assert(!res.headers['content-encoding'])
+    assert(!res.headers['transfer-encoding'])
 
-        done()
-      })
+    done()
   })
 
-  it('should not compress HEAD requests', (done) => {
+  it('should not compress HEAD requests', async (done) => {
     const app = new Koa()
 
     app.use(compress())
     app.use(sendString)
     server = app.listen()
 
-    request(server)
+    const res = await request(server)
       .head('/')
-      .expect(200, (err, res) => {
-        if (err) { return done(err) }
 
-        assert(!res.headers['content-encoding'])
+    assert(!res.headers['content-encoding'])
 
-        done()
-      })
+    done()
   })
 
   it('should not crash even if accept-encoding: sdch', (done) => {
@@ -245,7 +218,7 @@ describe('Compress', () => {
       .expect(200, done)
   })
 
-  it('should not compress if no accept-encoding is sent (with the default)', (done) => {
+  it('should not compress if no accept-encoding is sent (with the default)', async (done) => {
     const app = new Koa()
     app.use(compress({
       threshold: 0
@@ -256,22 +229,19 @@ describe('Compress', () => {
     })
     server = app.listen()
 
-    request(server)
+    const res = await request(server)
       .get('/')
       .set('Accept-Encoding', '')
-      .end((err, res) => {
-        if (err) { return done(err) }
 
-        assert(!res.headers['content-encoding'])
-        assert(!res.headers['transfer-encoding'])
-        assert.equal(res.headers['content-length'], '1024')
-        assert.equal(res.headers.vary, 'Accept-Encoding')
+    assert(!res.headers['content-encoding'])
+    assert(!res.headers['transfer-encoding'])
+    assert.equal(res.headers['content-length'], '1024')
+    assert.equal(res.headers.vary, 'Accept-Encoding')
 
-        done()
-      })
+    done()
   })
 
-  it('should be gzip if no accept-encoding is sent (with the standard default)', (done) => {
+  it('should be gzip if no accept-encoding is sent (with the standard default)', async (done) => {
     const app = new Koa()
     app.use(compress({
       threshold: 0,
@@ -283,17 +253,14 @@ describe('Compress', () => {
     })
     server = app.listen()
 
-    request(server)
+    const res = await request(server)
       .get('/')
       .set('Accept-Encoding', '')
-      .end((err, res) => {
-        if (err) { return done(err) }
 
-        assert.equal(res.headers['content-encoding'], 'gzip')
-        assert.equal(res.headers.vary, 'Accept-Encoding')
+    assert.equal(res.headers['content-encoding'], 'gzip')
+    assert.equal(res.headers.vary, 'Accept-Encoding')
 
-        done()
-      })
+    done()
   })
 
   it('should not crash if a type does not pass the filter', (done) => {
@@ -329,7 +296,7 @@ describe('Compress', () => {
       .expect('asdf', done)
   })
 
-  it('should support Z_SYNC_FLUSH', (done) => {
+  it('should support Z_SYNC_FLUSH', async (done) => {
     const app = new Koa()
 
     app.use(compress({
@@ -338,13 +305,61 @@ describe('Compress', () => {
     app.use(sendString)
     server = app.listen()
 
-    request(server)
+    const res = await request(server)
       .get('/')
       .expect(200)
-      .end((err, res) => {
-        if (err) { return done(err) }
 
-        // res.should.have.header('Content-Encoding', 'gzip')
+    assert.equal(res.headers['transfer-encoding'], 'chunked')
+    assert.equal(res.headers.vary, 'Accept-Encoding')
+    assert(!res.headers['content-length'])
+    assert.equal(res.text, string)
+
+    done()
+  })
+
+  describe('Cache-Control', () => {
+    ['no-transform', 'public, no-transform', 'no-transform, private', 'no-transform , max-age=1000', 'max-age=1000 , no-transform'].forEach(headerValue => {
+      it(`should skip Cache-Control: ${headerValue}`, async (done) => {
+        const app = new Koa()
+
+        app.use(compress())
+        app.use((ctx, next) => {
+          ctx.set('Cache-Control', headerValue)
+          next()
+        })
+        app.use(sendString)
+        server = app.listen()
+
+        const res = await request(server)
+          .get('/')
+          .expect(200)
+
+        assert.equal(res.headers['content-length'], '2048')
+        assert.equal(res.headers.vary, 'Accept-Encoding')
+        assert(!res.headers['content-encoding'])
+        assert(!res.headers['transfer-encoding'])
+        assert.equal(res.text, string)
+
+        done()
+      })
+    });
+
+    ['not-no-transform', 'public', 'no-transform-thingy'].forEach(headerValue => {
+      it(`should not skip Cache-Control: ${headerValue}`, async (done) => {
+        const app = new Koa()
+
+        app.use(compress())
+        app.use((ctx, next) => {
+          ctx.set('Cache-Control', headerValue)
+          next()
+        })
+        app.use(sendString)
+        server = app.listen()
+
+        const res = await request(server)
+          .get('/')
+          .expect(200)
+
         assert.equal(res.headers['transfer-encoding'], 'chunked')
         assert.equal(res.headers.vary, 'Accept-Encoding')
         assert(!res.headers['content-length'])
@@ -352,110 +367,46 @@ describe('Compress', () => {
 
         done()
       })
-  })
-
-  describe('Cache-Control', () => {
-    ['no-transform', 'public, no-transform', 'no-transform, private', 'no-transform , max-age=1000', 'max-age=1000 , no-transform'].forEach(headerValue => {
-      it(`should skip Cache-Control: ${headerValue}`, done => {
-        const app = new Koa()
-
-        app.use(compress())
-        app.use((ctx, next) => {
-          ctx.set('Cache-Control', headerValue)
-          next()
-        })
-        app.use(sendString)
-        server = app.listen()
-
-        request(server)
-          .get('/')
-          .expect(200)
-          .end((err, res) => {
-            if (err) { return done(err) }
-
-            assert.equal(res.headers['content-length'], '2048')
-            assert.equal(res.headers.vary, 'Accept-Encoding')
-            assert(!res.headers['content-encoding'])
-            assert(!res.headers['transfer-encoding'])
-            assert.equal(res.text, string)
-
-            done()
-          })
-      })
-    });
-
-    ['not-no-transform', 'public', 'no-transform-thingy'].forEach(headerValue => {
-      it(`should not skip Cache-Control: ${headerValue}`, done => {
-        const app = new Koa()
-
-        app.use(compress())
-        app.use((ctx, next) => {
-          ctx.set('Cache-Control', headerValue)
-          next()
-        })
-        app.use(sendString)
-        server = app.listen()
-
-        request(server)
-          .get('/')
-          .expect(200)
-          .end((err, res) => {
-            if (err) { return done(err) }
-
-            assert.equal(res.headers['transfer-encoding'], 'chunked')
-            assert.equal(res.headers.vary, 'Accept-Encoding')
-            assert(!res.headers['content-length'])
-            assert.equal(res.text, string)
-
-            done()
-          })
-      })
     })
   })
 
-  it('accept-encoding: deflate', (done) => {
+  it('accept-encoding: deflate', async (done) => {
     const app = new Koa()
 
     app.use(compress())
     app.use(sendBuffer)
     server = app.listen()
 
-    request(server)
+    const res = await request(server)
       .get('/')
       .set('Accept-Encoding', 'deflate')
       .expect(200)
-      .end((err, res) => {
-        if (err) { return done(err) }
 
-        assert.equal(res.headers.vary, 'Accept-Encoding')
-        assert.equal(res.headers['content-encoding'], 'deflate')
+    assert.equal(res.headers.vary, 'Accept-Encoding')
+    assert.equal(res.headers['content-encoding'], 'deflate')
 
-        done()
-      })
+    done()
   })
 
-  it('accept-encoding: gzip', (done) => {
+  it('accept-encoding: gzip', async (done) => {
     const app = new Koa()
 
     app.use(compress())
     app.use(sendBuffer)
     server = app.listen()
 
-    request(server)
+    const res = await request(server)
       .get('/')
       .set('Accept-Encoding', 'gzip, deflate')
       .expect(200)
-      .end((err, res) => {
-        if (err) { return done(err) }
 
-        assert.equal(res.headers.vary, 'Accept-Encoding')
-        assert.equal(res.headers['content-encoding'], 'gzip')
+    assert.equal(res.headers.vary, 'Accept-Encoding')
+    assert.equal(res.headers['content-encoding'], 'gzip')
 
-        done()
-      })
+    done()
   })
 
-  it('accept-encoding: br', (done) => {
+  it('accept-encoding: br', async (done) => {
     if (!process.versions.brotli) return done()
 
     const app = new Koa()
@@ -464,38 +415,32 @@ describe('Compress', () => {
     app.use(sendBuffer)
     server = app.listen()
 
-    request(server)
+    const res = await request(server)
       .get('/')
       .set('Accept-Encoding', 'br')
       .expect(200)
-      .end((err, res) => {
-        if (err) { return done(err) }
 
-        assert.equal(res.headers.vary, 'Accept-Encoding')
-        assert.equal(res.headers['content-encoding'], 'br')
+    assert.equal(res.headers.vary, 'Accept-Encoding')
+    assert.equal(res.headers['content-encoding'], 'br')
 
-        done()
-      })
+    done()
   })
 
-  it('accept-encoding: br (banned, should be gzip)', (done) => {
+  it('accept-encoding: br (banned, should be gzip)', async (done) => {
     const app = new Koa()
 
     app.use(compress({ br: false }))
     app.use(sendBuffer)
     server = app.listen()
 
-    request(server)
+    const res = await request(server)
       .get('/')
       .set('Accept-Encoding', 'gzip, deflate, br')
       .expect(200)
-      .end((err, res) => {
-        if (err) { return done(err) }
 
-        assert.equal(res.headers.vary, 'Accept-Encoding')
-        assert.equal(res.headers['content-encoding'], 'gzip')
+    assert.equal(res.headers.vary, 'Accept-Encoding')
+    assert.equal(res.headers['content-encoding'], 'gzip')
 
-        done()
-      })
+    done()
   })
 })

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -43,7 +43,7 @@ describe('Compress', () => {
     done()
   })
 
-  it('should not compress strings below threshold', async (done) => {
+  test('should not compress strings below threshold', async (done) => {
     const app = new Koa()
 
     app.use(compress({
@@ -65,7 +65,7 @@ describe('Compress', () => {
     done()
   })
 
-  it('should compress JSON body', async (done) => {
+  test('should compress JSON body', async (done) => {
     const app = new Koa()
     const jsonBody = { status: 200, message: 'ok', data: string }
 
@@ -87,7 +87,7 @@ describe('Compress', () => {
     done()
   })
 
-  it('should not compress JSON body below threshold', async (done) => {
+  test('should not compress JSON body below threshold', async (done) => {
     const app = new Koa()
     const jsonBody = { status: 200, message: 'ok' }
 
@@ -109,7 +109,7 @@ describe('Compress', () => {
     done()
   })
 
-  it('should compress buffers', async (done) => {
+  test('should compress buffers', async (done) => {
     const app = new Koa()
 
     app.use(compress())
@@ -127,7 +127,7 @@ describe('Compress', () => {
     done()
   })
 
-  it('should compress streams', async (done) => {
+  test('should compress streams', async (done) => {
     const app = new Koa()
 
     app.use(compress())
@@ -150,7 +150,7 @@ describe('Compress', () => {
     done()
   })
 
-  it('should compress when ctx.compress === true', async (done) => {
+  test('should compress when ctx.compress === true', async (done) => {
     const app = new Koa()
 
     app.use(compress())
@@ -168,7 +168,7 @@ describe('Compress', () => {
     done()
   })
 
-  it('should not compress when ctx.compress === false', async (done) => {
+  test('should not compress when ctx.compress === false', async (done) => {
     const app = new Koa()
 
     app.use(compress())
@@ -190,7 +190,7 @@ describe('Compress', () => {
     done()
   })
 
-  it('should not compress HEAD requests', async (done) => {
+  test('should not compress HEAD requests', async (done) => {
     const app = new Koa()
 
     app.use(compress())
@@ -205,7 +205,7 @@ describe('Compress', () => {
     done()
   })
 
-  it('should not crash even if accept-encoding: sdch', (done) => {
+  test('should not crash even if accept-encoding: sdch', (done) => {
     const app = new Koa()
 
     app.use(compress())
@@ -218,7 +218,7 @@ describe('Compress', () => {
       .expect(200, done)
   })
 
-  it('should not compress if no accept-encoding is sent (with the default)', async (done) => {
+  test('should not compress if no accept-encoding is sent (with the default)', async (done) => {
     const app = new Koa()
     app.use(compress({
       threshold: 0
@@ -241,7 +241,7 @@ describe('Compress', () => {
     done()
   })
 
-  it('should be gzip if no accept-encoding is sent (with the standard default)', async (done) => {
+  test('should be gzip if no accept-encoding is sent (with the standard default)', async (done) => {
     const app = new Koa()
     app.use(compress({
       threshold: 0,
@@ -263,7 +263,7 @@ describe('Compress', () => {
     done()
   })
 
-  it('should not crash if a type does not pass the filter', (done) => {
+  test('should not crash if a type does not pass the filter', (done) => {
     const app = new Koa()
 
     app.use(compress())
@@ -278,7 +278,7 @@ describe('Compress', () => {
       .expect(200, done)
   })
 
-  it('should not compress when transfer-encoding is already set', (done) => {
+  test('should not compress when transfer-encoding is already set', (done) => {
     const app = new Koa()
 
     app.use(compress({
@@ -296,7 +296,7 @@ describe('Compress', () => {
       .expect('asdf', done)
   })
 
-  it('should support Z_SYNC_FLUSH', async (done) => {
+  test('should support Z_SYNC_FLUSH', async (done) => {
     const app = new Koa()
 
     app.use(compress({
@@ -319,7 +319,7 @@ describe('Compress', () => {
 
   describe('Cache-Control', () => {
     ['no-transform', 'public, no-transform', 'no-transform, private', 'no-transform , max-age=1000', 'max-age=1000 , no-transform'].forEach(headerValue => {
-      it(`should skip Cache-Control: ${headerValue}`, async (done) => {
+      test(`should skip Cache-Control: ${headerValue}`, async (done) => {
         const app = new Koa()
 
         app.use(compress())
@@ -345,7 +345,7 @@ describe('Compress', () => {
     });
 
     ['not-no-transform', 'public', 'no-transform-thingy'].forEach(headerValue => {
-      it(`should not skip Cache-Control: ${headerValue}`, async (done) => {
+      test(`should not skip Cache-Control: ${headerValue}`, async (done) => {
         const app = new Koa()
 
         app.use(compress())
@@ -370,7 +370,7 @@ describe('Compress', () => {
     })
   })
 
-  it('accept-encoding: deflate', async (done) => {
+  test('accept-encoding: deflate', async (done) => {
     const app = new Koa()
 
     app.use(compress())
@@ -388,7 +388,7 @@ describe('Compress', () => {
     done()
   })
 
-  it('accept-encoding: gzip', async (done) => {
+  test('accept-encoding: gzip', async (done) => {
     const app = new Koa()
 
     app.use(compress())
@@ -406,7 +406,7 @@ describe('Compress', () => {
     done()
   })
 
-  it('accept-encoding: br', async (done) => {
+  test('accept-encoding: br', async (done) => {
     if (!process.versions.brotli) return done()
 
     const app = new Koa()
@@ -426,7 +426,7 @@ describe('Compress', () => {
     done()
   })
 
-  it('accept-encoding: br (banned, should be gzip)', async (done) => {
+  test('accept-encoding: br (banned, should be gzip)', async (done) => {
     const app = new Koa()
 
     app.use(compress({ br: false }))


### PR DESCRIPTION
# Why

Unit tests use the older callback form and can be updated to the async/await pattern. Fixes #105 .

# How

Switched usage from callbacks to `const res = await(server)...` pattern. Also switched from using `it` to `test` to conform with other test suites.