### PR TITLE
fix: correct brotli options format

### DIFF
--- a/lib/encodings.js
+++ b/lib/encodings.js
@@ -89,7 +89,9 @@ Encodings.encodingMethodDefaultOptions = {
   gzip: {},
   deflate: {},
   br: {
-    [zlib.constants.BROTLI_PARAM_QUALITY]: 4
+    params: {      
+      [zlib.constants.BROTLI_PARAM_QUALITY]: 4
+    }
   }
 }
 


### PR DESCRIPTION
3d205cd88b48980c840b8b8f889676c2b3a4c6e2 didn't actually fix the default compression issue described in #121 because the zlib format expects quality to be inside [an option called `params`](https://nodejs.org/api/zlib.html#class-brotlioptions)

**Example Test Sever**
```js
const Koa = require('koa')
const {Stream} = require('stream')
const app = (module.exports = new Koa())
const compress = require('koa-compress')

app.use(async (ctx, next) => {
  await next()

  if (ctx.body instanceof Stream) {
    console.time('request')
    ctx.body.on('end', () => console.timeEnd('request'))
  }
})

app.use(compress())

app.use(async function(ctx) {
  ctx.compress = true
  ctx.body = require('crypto').randomBytes(10_000_000)
})

if (!module.parent) app.listen(3000, () => console.log('Server is up!'))
```

**Before**
```
$ node server &
Server is up!
$ curl http://localhost:3000 -H 'Accept-Encoding: br' > /dev/null
request: 8.398s
request: 8.354s
```
**After**
```
$ node server &
Server is up!
$ curl http://localhost:3000 -H 'Accept-Encoding: br' > /dev/null
request: 90.855ms
request: 71.504ms
```