### PR TITLE
fix: skip compression for 206 and Content-Range responses

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -831,3 +831,50 @@ describe('Compress', () => {
     assert(res.headers['content-encoding'] === 'gzip')
   })
 })
+
+describe('Range Responses', () => {
+  let server
+
+  afterEach(() => server && server.close())
+
+  test('should not compress 206 Partial Content responses', async () => {
+    const app = new Koa()
+    app.use(compress({ threshold: 0 }))
+    app.use((ctx) => {
+      ctx.status = 206
+      ctx.type = 'text'
+      ctx.set('Content-Range', 'bytes 0-4/12')
+      ctx.body = 'hello'
+    })
+    server = app.listen()
+
+    const res = await request(server)
+      .get('/')
+      .set('Accept-Encoding', 'gzip')
+
+    assert.equal(res.status, 206)
+    assert.equal(res.headers['content-encoding'], undefined)
+    assert.equal(res.headers['content-range'], 'bytes 0-4/12')
+    assert.equal(res.text, 'hello')
+  })
+
+  test('should not compress responses carrying a Content-Range header', async () => {
+    const app = new Koa()
+    app.use(compress({ threshold: 0 }))
+    app.use((ctx) => {
+      ctx.type = 'text'
+      ctx.set('Content-Range', 'bytes 0-4/12')
+      ctx.body = 'hello'
+    })
+    server = app.listen()
+
+    const res = await request(server)
+      .get('/')
+      .set('Accept-Encoding', 'gzip')
+
+    assert.equal(res.status, 200)
+    assert.equal(res.headers['content-encoding'], undefined)
+    assert.equal(res.headers['content-range'], 'bytes 0-4/12')
+    assert.equal(res.text, 'hello')
+  })
+})

--- a/lib/index.js
+++ b/lib/index.js
@@ -102,6 +102,9 @@ module.exports = (options = {}) => {
       ctx.compress === false ||
       ctx.request.method === 'HEAD' ||
       emptyBodyStatuses.has(+ctx.response.status) ||
+      // don't compress partial content: Content-Range describes unencoded byte offsets
+      +ctx.response.status === 206 ||
+      ctx.response.get('Content-Range') ||
       ctx.response.get('Content-Encoding') ||
       // forced compression or implied
       !(ctx.compress === true || filter(type)) ||

--- a/lib/index.js
+++ b/lib/index.js
@@ -103,8 +103,9 @@ module.exports = (options = {}) => {
       ctx.request.method === 'HEAD' ||
       emptyBodyStatuses.has(+ctx.response.status) ||
       // don't compress partial content: Content-Range describes unencoded byte offsets
-      +ctx.response.status === 206 ||
+      ctx.status === 206 ||
       ctx.response.get('Content-Range') ||
+      /^multipart\/byteranges\b/i.test(ctx.response.get('Content-Type') || '') ||
       ctx.response.get('Content-Encoding') ||
       // forced compression or implied
       !(ctx.compress === true || filter(type)) ||

--- a/lib/index.js
+++ b/lib/index.js
@@ -101,7 +101,7 @@ module.exports = (options = {}) => {
       !ctx.writable ||
       ctx.compress === false ||
       ctx.request.method === 'HEAD' ||
-      emptyBodyStatuses.has(+ctx.response.status) ||
+      emptyBodyStatuses.has(ctx.status) ||
       // don't compress partial content: Content-Range describes unencoded byte offsets
       ctx.status === 206 ||
       ctx.response.get('Content-Range') ||


### PR DESCRIPTION
## Problem

`koa-compress` compresses `206 Partial Content` responses even though their `Content-Range` header describes **unencoded** byte offsets. After compression the body shrinks but `Content-Range` still refers to the pre-compression range, so a range-aware client stitching parts together receives corrupted data.

The same class of bug was recently fixed in [hono/compress](https://github.com/honojs/hono/pull/5023) and [@fastify/compress](https://github.com/fastify/fastify-compress/pull/402).

## Fix

Two new guards in the early-exit block (`lib/index.js`):

```js
// don't compress partial content: Content-Range describes unencoded byte offsets
+ctx.response.status === 206 ||
ctx.response.get('Content-Range') ||
```

## Tests

New `Range Responses` describe block in `__tests__/index.js` with two cases:

1. `206 Partial Content` — no `Content-Encoding`, `Content-Range` preserved
2. `200` with `Content-Range` header — same

```
npm test  →  53 passed (51 existing + 2 new), 0 failed
```

## Summary by Sourcery

Skip response compression when serving partial or ranged content to avoid corrupting `Content-Range` semantics.

Bug Fixes:
- Prevent compression of 206 Partial Content responses so that byte ranges remain consistent with `Content-Range` headers.
- Avoid compressing 200 OK responses that include a `Content-Range` header to ensure clients receive correctly ranged bodies.

Tests:
- Add tests verifying that 206 Partial Content responses are not compressed and preserve their `Content-Range` header and body.
- Add tests ensuring 200 responses with a `Content-Range` header are not compressed despite gzip being accepted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented compression for range/partial-content responses by skipping compression when the response is `206 Partial Content`, when a `Content-Range` header is present, or when the content type is `multipart/byteranges`.
* **Tests**
  * Added coverage to confirm range responses are not compressed for both `206` replies and `200` responses that include `Content-Range`, including proper local server setup/teardown after each test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->