### PR TITLE
chore: add homepage and bugs URLs to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,5 +75,9 @@
       "expect",
       "it"
     ]
+  },
+  "homepage": "https://github.com/koajs/compress",
+  "bugs": {
+    "url": "https://github.com/koajs/compress/issues"
   }
 }


### PR DESCRIPTION
Adds `homepage` and `bugs.url` fields to package.json so users can easily find the project website and report issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected package metadata structure so homepage and bug-report link settings are properly recognized at the top level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->